### PR TITLE
Helper stopped working in CodeceptJS 3.x: Error: Could not load helper CmdHelper from module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const spawn = require( 'child_process' ).spawn;
 const platform = require( 'os' ).platform;
 const splitToObject = require( 'split-cmd' ).splitToObject;
-const Helper = require( 'codeceptjs' ).helper;
 
 /**
  * Command helper


### PR DESCRIPTION
Fixed issue "Could not load helper CmdHelper". Based on [an advice](https://codeceptjs.slack.com/archives/C94G8JXJB/p1607009137470500) in CodeceptJS Slack channel.

I checked that the fix works in my test with CodeceptJS 2.6.11 (latest 2.x) and with CodeceptJS 3.0.2 (latest 3.x)