### PR TITLE
Revert "Helper stopped working in CodeceptJS 3.x: Error: Could not load helper CmdHelper from module"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const spawn = require( 'child_process' ).spawn;
 const platform = require( 'os' ).platform;
 const splitToObject = require( 'split-cmd' ).splitToObject;
+const Helper = require( 'codeceptjs' ).helper;
 
 /**
  * Command helper


### PR DESCRIPTION
Reverts thiagodp/codeceptjs-cmdhelper#5 and reopens #4 