### PR TITLE
Create TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,24 @@
+export = CmdHelper;
+/**
+ * Command helper
+ *
+ * @author Thiago Delgado Pinto
+ */
+declare class CmdHelper {
+    /**
+     * Constructor
+     *
+     * @param {object} config Configuration declared in the CodeceptJS configuration file.
+     */
+    constructor(config: object);
+    options: any;
+    /**
+     * Executes the given command.
+     *
+     * @param {string} command Command to execute.
+     * @param {object} [options] Same options as in NodeJS' spawn(), plus `showOutput: boolean`. Optional. Default is `{ shell: true, showOutput: true }`.
+     *
+     * @returns Promise with the returning execution status code (0 means success)
+     */
+    runCommand(command: string, options?: object): any;
+}

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class CmdHelper extends Helper {
      * Executes the given command.
      *
      * @param {string} command Command to execute.
-     * @param {object} options Same options as in NodeJS' spawn(), plus `showOutput: boolean`. Optional. Default is `{ shell: true, showOutput: true }`.
+     * @param {object} [options] Same options as in NodeJS' spawn(), plus `showOutput: boolean`. Optional. Default is `{ shell: true, showOutput: true }`.
      *
      * @returns Promise with the returning execution status code (0 means success)
      */


### PR DESCRIPTION
Motivation: I started to migrate my JS tests to TS format and want to be able to have functional IntelliSense in VSCode and TS check in TS tests:

![runCommand](https://user-images.githubusercontent.com/12584138/133488544-aeeb2042-cb89-47f8-b183-c7b5f8e20cc8.png)

- Param in JSDoc was set as optional (https://jsdoc.app/tags-param.html#optional-parameters-and-default-values) so that generated TS definition allows omit it (otherwise TS check fails when calling `I.runCommand` without that)

- TS definition was created by `npx -p typescript tsc index.js --declaration --allowJs --emitDeclarationOnly`, see https://www.typescriptlang.org/docs/handbook/declaration-files/dts-from-js.html
