### PR TITLE
Fix DEP0190 deprecation warning on Node.js 24 when shell: true

### DIFF
--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -12,4 +12,24 @@ describe( 'CmdHelper', () => {
         await helper.runCommand( 'echo "bar"', { showOutput: false } );
     } );
 
+    it( 'does not emit DEP0190 when running a command with arguments (shell: true)', ( done ) => {
+        // Run in a subprocess so the warning is not suppressed by Node's once-per-process dedup
+        const { spawn } = require( 'child_process' );
+        const script = `
+            const CmdHelper = require( '.' );
+            const helper = new CmdHelper();
+            helper.runCommand( 'echo hello world', { showOutput: false } ).then( () => process.exit( 0 ) );
+        `;
+        const child = spawn( process.execPath, [ '-e', script ], { cwd: require( 'path' ).join( __dirname, '..' ) } );
+        let stderr = '';
+        child.stderr.on( 'data', ( chunk ) => { stderr += chunk; } );
+        child.on( 'exit', () => {
+            if ( stderr.includes( 'DEP0190' ) ) {
+                done( new Error( `Unexpected DEP0190 warning emitted:\n${stderr}` ) );
+            } else {
+                done();
+            }
+        } );
+    } );
+
 } );

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ class CmdHelper extends Helper {
             opt[ 'shell' ] = true;
         }
 
-        const cmdObj = splitToObject( command );
+        // When shell: true, pass the full command string with no args array to avoid
+        // Node.js 24 DEP0190 (args concatenated without escaping under shell mode).
+        const cmdObj = opt.shell ? { command, args: [] } : splitToObject( command );
 
         return new Promise( ( resolve, reject ) => {
 


### PR DESCRIPTION
## Problem

Starting with Node.js 24, calling `I.runCommand()` with a command that has arguments emits:

```
(node:XXXX) [DEP0190] DeprecationWarning: Passing args to a child process with shell
option true can lead to security vulnerabilities, as the arguments are not escaped,
only concatenated.
```

Root cause: `runCommand` calls `splitToObject(command)` unconditionally, producing a non-empty `args` array, then passes both `args` and `shell: true` to `spawn()`. Node.js 24 warns whenever args is non-empty alongside `shell: true`.

## Fix

When `shell: true`, the shell handles tokenisation itself — pre-splitting is unnecessary. Skip `splitToObject()` in that case and pass the full command string with an empty args array:

```js
const cmdObj = opt.shell ? { command, args: [] } : splitToObject( command );
```

## Test

Added a unit test that spawns a fresh subprocess (to bypass Node's once-per-process deduplication of deprecation warnings) and asserts no DEP0190 is emitted when running a multi-word command under `shell: true`.

Verified on Node.js 24.15.0:
- ❌ test **fails** without the fix (DEP0190 is emitted)
- ✅ test **passes** with the fix

Closes #17